### PR TITLE
Fix log creation for custom paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,9 @@ def get_repo_info():
         return {"repo": "", "branch": ""}
 
 def write_log_entry(log_path, entry):
-    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    log_dir = os.path.dirname(log_path)
+    if log_dir:
+        os.makedirs(log_dir, exist_ok=True)
     with open(log_path, "a", encoding="utf-8") as log_file:
         log_file.write(json.dumps(entry) + "\n")
 


### PR DESCRIPTION
## Summary
- handle empty directory component when writing logs

## Testing
- `python -m py_compile main.py`
- `python -m py_compile diff_reader.py openai_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_6842236fc01c83308241b0ab7d445277